### PR TITLE
Split out nodes and links

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
   "extends": "airbnb",
+  "rules": {
+    "react/jsx-no-bind": 0,
+  },
 }

--- a/src/models/atom_model.js
+++ b/src/models/atom_model.js
@@ -1,0 +1,10 @@
+import Backbone from 'backbone';
+
+const AtomsModel = Backbone.Model.extend({
+  defaults: {
+    nodes: [],
+    clicked_atom_index: null,
+  },
+});
+
+export default AtomsModel;

--- a/src/models/links_model.js
+++ b/src/models/links_model.js
@@ -1,0 +1,9 @@
+import Backbone from 'backbone';
+
+const LinksModel = Backbone.Model.extend({
+  defaults: {
+    links: [],
+  },
+});
+
+export default LinksModel;

--- a/src/models/nodes_model.js
+++ b/src/models/nodes_model.js
@@ -1,10 +1,10 @@
 import Backbone from 'backbone';
 
-const AtomModel = Backbone.Model.extend({
+const NodesModel = Backbone.Model.extend({
   defaults: {
     nodes: [],
     clicked_atom_index: null,
   },
 });
 
-export default AtomModel;
+export default NodesModel;

--- a/src/views/links_view.js
+++ b/src/views/links_view.js
@@ -1,0 +1,88 @@
+import Backbone from 'backbone';
+import molViewUtils from '../utils/mol_view_utils';
+
+const LinksView = Backbone.View.extend({
+  initialize(options) {
+    this.svg = options.svg;
+  },
+
+  render() {
+    const links = this.svg
+      .selectAll('.link')
+      .data(this.model.get('links'));
+
+    links.selectAll('*').remove();
+
+    links.enter()
+      .append('g');
+
+    links.attr('class', 'link');
+
+    // all edges (includes both bonds and distance constraints)
+    links.append('line')
+      .attr('source', (d) => d.source.index)
+      .attr('target', (d) => d.target.index)
+      .style('stroke-width', molViewUtils.getBondWidth)
+      .style('stroke-dasharray', (d) => {
+        if (d.style === 'dashed') {
+          return 5;
+        }
+
+        return 0;
+      })
+      .style('stroke', (d) => molViewUtils.chooseColor(d, 'black'))
+      .style('opacity', (d) => {
+        if (d.bond !== 0) {
+          return undefined;
+        }
+        return 0.0;
+      });
+
+    // text placeholders for all edges
+    links.append('text')
+        .attr('x', (d) => d.source.x)
+        .attr('y', (d) => d.source.y)
+        .attr('text-anchor', 'middle')
+        .text(() => ' ');
+
+    // double and triple bonds
+    links
+      .filter((d) => d.bond > 1)
+      .append('line')
+      .attr('class', 'separator')
+      .style('stroke', '#FFF')
+      .style('stroke-width', (d) => `${d.bond * 4 - 5}px`);
+
+    // triple bonds
+    links
+      .filter((d) => d.bond === 3)
+      .append('line')
+      .attr('class', 'separator')
+      .style('stroke', (d) => molViewUtils.chooseColor(d, 'black'))
+      .style('stroke-width', () => molViewUtils.getBondWidth(1));
+
+    return this;
+  },
+
+  renderPosition() {
+    const links = this.svg.selectAll('.link');
+
+    // keep edges pinned to their nodes
+    links.selectAll('line')
+      .attr('x1', (d) => d.source.x)
+      .attr('y1', (d) => d.source.y)
+      .attr('x2', (d) => d.target.x)
+      .attr('y2', (d) => d.target.y);
+
+    // keep edge labels pinned to the edges
+    links.selectAll('text')
+      .attr('x', (d) =>
+        (d.source.x + d.target.x) / 2.0
+      )
+      .attr('y', (d) =>
+        (d.source.y + d.target.y) / 2.0
+      );
+  },
+});
+
+export default LinksView;

--- a/src/views/links_view.js
+++ b/src/views/links_view.js
@@ -11,15 +11,13 @@ const LinksView = Backbone.View.extend({
       .selectAll('.link')
       .data(this.model.get('links'));
 
-    links.selectAll('*').remove();
-
-    links.enter()
-      .append('g');
-
-    links.attr('class', 'link');
+    const newLinksG = links.enter()
+      .append('g')
+      .attr('class', 'link');
 
     // all edges (includes both bonds and distance constraints)
-    links.append('line')
+    newLinksG
+      .append('line')
       .attr('source', (d) => d.source.index)
       .attr('target', (d) => d.target.index)
       .style('stroke-width', molViewUtils.getBondWidth)
@@ -39,14 +37,15 @@ const LinksView = Backbone.View.extend({
       });
 
     // text placeholders for all edges
-    links.append('text')
-        .attr('x', (d) => d.source.x)
-        .attr('y', (d) => d.source.y)
-        .attr('text-anchor', 'middle')
-        .text(() => ' ');
+    newLinksG
+      .append('text')
+      .attr('x', (d) => d.source.x)
+      .attr('y', (d) => d.source.y)
+      .attr('text-anchor', 'middle')
+      .text(() => ' ');
 
     // double and triple bonds
-    links
+    newLinksG
       .filter((d) => d.bond > 1)
       .append('line')
       .attr('class', 'separator')
@@ -54,7 +53,7 @@ const LinksView = Backbone.View.extend({
       .style('stroke-width', (d) => `${d.bond * 4 - 5}px`);
 
     // triple bonds
-    links
+    newLinksG
       .filter((d) => d.bond === 3)
       .append('line')
       .attr('class', 'separator')

--- a/src/views/nbmolviz2d_view.js
+++ b/src/views/nbmolviz2d_view.js
@@ -91,17 +91,6 @@ const Nbmolviz2dView = Backbone.View.extend({
     console.log(`${this.viewerId} is ready`);
   },
 
-  updateHighlightAtoms(atoms) {
-    const svgAtoms = this.svgNodes;
-    this.highlightedAtoms.forEach((x) => {
-      svgAtoms[x].style.stroke = null;
-    });
-    this.highlightedAtoms = atoms;
-    atoms.forEach((x) => {
-      svgAtoms[x].style.stroke = '#39F8FF';
-    });
-  },
-
   setCss() {
     if (document.querySelectorAll('#graph_css_style').length > 0) {
       return;
@@ -116,8 +105,6 @@ const Nbmolviz2dView = Backbone.View.extend({
     document.getElementsByTagName('head')[0].appendChild(graphStyle);
   },
 
-  /*
-   * TODO these are unused, delete them?
   setAtomStyle(atoms, atomSpec) {
     this.applyStyleSpec(atoms, this.svgNodes, atomSpec);
   },
@@ -163,7 +150,6 @@ const Nbmolviz2dView = Backbone.View.extend({
       link.children[1].style[st] = spec[st];
     });
   },
-  */
 
   indexSvgElements() {
     this.svgNodes = {};

--- a/src/views/nbmolviz2d_view.js
+++ b/src/views/nbmolviz2d_view.js
@@ -225,6 +225,7 @@ const Nbmolviz2dView = Backbone.View.extend({
     // afraid to touch the root model for now
     nodesModel.on('change:clicked_atom_index', () => {
       this.model.set('clicked_atom_index', nodesModel.get('clicked_atom_index'));
+      this.model.save();
     });
 
     const nodesView = new NodesView({

--- a/src/views/nbmolviz2d_view.js
+++ b/src/views/nbmolviz2d_view.js
@@ -180,15 +180,16 @@ const Nbmolviz2dView = Backbone.View.extend({
     console.log(JSON.stringify(graph));
     console.log('up8date');
 
-    d3.select('svg').remove();
+    if (this.el.querySelectorAll('svg').length) {
+      this.svg = d3.select(this.el).select('svg');
+    } else {
+      this.svg = d3.select(this.el).append('svg');
+    }
 
-    const svg = d3
-      .select(this.el)
-      .append('svg')
+    this.svg
       .attr('width', width)
       .attr('height', height)
       .attr('border', 1);
-    this.svg = svg;
 
     /*
     const borderPath = svg.append('rect')
@@ -211,16 +212,24 @@ const Nbmolviz2dView = Backbone.View.extend({
       model: new LinksModel({
         links: this.graph.links,
       }),
-      svg,
+      svg: this.svg,
     });
     linksView.render();
 
+    const nodesModel = new NodesModel({
+      nodes: this.graph.nodes,
+      clicked_atom_index: this.model.get('clicked_atom_index'),
+    });
+
+    // TODO ideally we shouldn't duplicate data and keep it in sync, but I'm
+    // afraid to touch the root model for now
+    nodesModel.on('change:clicked_atom_index', () => {
+      this.model.set('clicked_atom_index', nodesModel.get('clicked_atom_index'));
+    });
+
     const nodesView = new NodesView({
-      model: new NodesModel({
-        nodes: this.graph.nodes,
-        clicked_atom_index: this.model.get('clicked_atom_index'),
-      }),
-      svg,
+      model: nodesModel,
+      svg: this.svg,
       force,
     });
     nodesView.render();

--- a/src/views/nodes_model.js
+++ b/src/views/nodes_model.js
@@ -1,0 +1,10 @@
+import Backbone from 'backbone';
+
+const AtomModel = Backbone.Model.extend({
+  defaults: {
+    nodes: [],
+    clicked_atom_index: null,
+  },
+});
+
+export default AtomModel;

--- a/src/views/nodes_view.js
+++ b/src/views/nodes_view.js
@@ -4,7 +4,7 @@ import molViewUtils from '../utils/mol_view_utils';
 
 const SELECTED_COLOR = '#39f8ff';
 
-const AtomsView = Backbone.View.extend({
+const NodesView = Backbone.View.extend({
   initialize(options) {
     this.svg = options.svg;
     this.force = options.force;
@@ -17,20 +17,20 @@ const AtomsView = Backbone.View.extend({
   },
 
   render() {
-    const node = this.svg
+    const nodes = this.svg
       .selectAll('.node')
       .data(this.model.get('nodes'), (d) => d.index);
 
     // Clear everything inside the groups so it can be redrawn
-    node.selectAll('*').remove();
+    nodes.selectAll('*').remove();
 
-    node.enter()
+    nodes.enter()
       .append('g')
       .on('click', this.onClick.bind(this));
 
     const clickedAtomIndex = this.model.get('clicked_atom_index');
 
-    node
+    nodes
       .attr('class', (d) => {
         const selectedClass = d.index === clickedAtomIndex ? 'selected' : '';
         return `node ${selectedClass}`;
@@ -41,7 +41,7 @@ const AtomsView = Backbone.View.extend({
     const radius = d3.scale.sqrt().range([0, 6]);
 
     // circle for each atom (background color white by default)
-    node.append('circle')
+    nodes.append('circle')
       .attr('class', 'atom-circle')
       .attr('r', (d) => radius(molViewUtils.withDefault(d.size, 1.5)))
       .style('fill', (d) => molViewUtils.chooseColor(d, 'white'))
@@ -50,7 +50,7 @@ const AtomsView = Backbone.View.extend({
       );
 
     // atom labels
-    node.append('text')
+    nodes.append('text')
       .attr('class', 'atom-label')
       .attr('dy', '.35em')
       .attr('text-anchor', 'middle')
@@ -60,7 +60,7 @@ const AtomsView = Backbone.View.extend({
       })
       .text((d) => d.atom);
 
-    node.attr('transform', (d) =>
+    nodes.attr('transform', (d) =>
       `translate(${d.x || 0},${d.y || 0})`
     );
 
@@ -77,4 +77,4 @@ const AtomsView = Backbone.View.extend({
   },
 });
 
-export default AtomsView;
+export default NodesView;

--- a/src/views/nodes_view.js
+++ b/src/views/nodes_view.js
@@ -1,0 +1,80 @@
+import Backbone from 'backbone';
+import d3 from 'd3';
+import molViewUtils from '../utils/mol_view_utils';
+
+const SELECTED_COLOR = '#39f8ff';
+
+const AtomsView = Backbone.View.extend({
+  initialize(options) {
+    this.svg = options.svg;
+    this.force = options.force;
+    this.model.on('change', this.render.bind(this));
+  },
+
+  onClick(node) {
+    this.model.set('clicked_atom_index', node.index * 1);
+    this.model.save();
+  },
+
+  render() {
+    const node = this.svg
+      .selectAll('.node')
+      .data(this.model.get('nodes'), (d) => d.index);
+
+    // Clear everything inside the groups so it can be redrawn
+    node.selectAll('*').remove();
+
+    node.enter()
+      .append('g')
+      .on('click', this.onClick.bind(this));
+
+    const clickedAtomIndex = this.model.get('clicked_atom_index');
+
+    node
+      .attr('class', (d) => {
+        const selectedClass = d.index === clickedAtomIndex ? 'selected' : '';
+        return `node ${selectedClass}`;
+      })
+      .attr('index', (d) => d.index)
+      .call(this.force.drag);
+
+    const radius = d3.scale.sqrt().range([0, 6]);
+
+    // circle for each atom (background color white by default)
+    node.append('circle')
+      .attr('class', 'atom-circle')
+      .attr('r', (d) => radius(molViewUtils.withDefault(d.size, 1.5)))
+      .style('fill', (d) => molViewUtils.chooseColor(d, 'white'))
+      .style('stroke', (d) =>
+        (d.index === clickedAtomIndex ? SELECTED_COLOR : '')
+      );
+
+    // atom labels
+    node.append('text')
+      .attr('class', 'atom-label')
+      .attr('dy', '.35em')
+      .attr('text-anchor', 'middle')
+      .attr('fill', (d) => {
+        const color = d.index === clickedAtomIndex ? SELECTED_COLOR : '#000000';
+        return molViewUtils.withDefault(d.textcolor, color);
+      })
+      .text((d) => d.atom);
+
+    node.attr('transform', (d) =>
+      `translate(${d.x || 0},${d.y || 0})`
+    );
+
+    this.renderTransform();
+
+    return this;
+  },
+
+  renderTransform() {
+    this.svg.selectAll('.node')
+      .attr('transform', (d) =>
+        `translate(${d.x || 0},${d.y || 0})`
+      );
+  },
+});
+
+export default AtomsView;


### PR DESCRIPTION
This PR is mainly an attempt at simplifying the architecture of the app by splitting out nodes and links from the main view into their own models and views.  I'm trying to move toward a more data-bound approach, so I also got rid of at least one RPC call here.

I might do a bigger refactor or rewrite here at some point, but I'll save that until I know we have a good reason to.